### PR TITLE
Moved betdetail inputs to own component

### DIFF
--- a/client/src/features/add-bet/components/forms/add-bet-form/AddBetDetailsForm.tsx
+++ b/client/src/features/add-bet/components/forms/add-bet-form/AddBetDetailsForm.tsx
@@ -10,17 +10,9 @@ import {
 } from "@/utils";
 
 import { Bet } from "@utils/types";
-import { isBetBuilderType } from "@/pages/add-bet/betUtils";
-import {
-  DateInput,
-  FreeLiveInput,
-  MatchInput,
-  OddsInput,
-  SelectionInput,
-  TypeInput,
-  BetBuilderInput,
-} from "../../add-bet-inputs";
+
 import { Button2 } from "@/components";
+import { BetDetailInputs } from "./BetDetailInputs";
 
 type AddBetDetailsFormProps = {
   myBet: Bet;
@@ -104,58 +96,16 @@ export const AddBetDetailsForm = ({
         data-testid="addbet-form"
         onSubmit={handleMyBet}
       >
-        <MatchInput
+        <BetDetailInputs
           handleBetInput={handleBetInput}
-          details={addBetDetails}
+          addBetDetails={addBetDetails}
           disabled={disabled}
-          error={errors}
+          setErrors={setErrors}
+          errors={errors}
           handleFocus={handleFocus}
           handleBlur={handleBlur}
-        />
-        <TypeInput
-          handleSelectChange={handleDetailsSelect}
-          details={addBetDetails}
-          disabled={disabled}
-        />
-        <FreeLiveInput
-          handleBetInput={handleBetInput}
-          details={addBetDetails}
-          disabled={disabled}
-        />
-        {isBetBuilderType(addBetDetails.bet_type) ? (
-          <BetBuilderInput
-            handleBetInput={handleBetInput}
-            details={addBetDetails}
-            setDetails={setAddBetDetails}
-            disabled={disabled}
-            error={errors}
-            handleFocus={handleFocus}
-            handleBlur={handleBlur}
-          />
-        ) : (
-          <SelectionInput
-            handleBetInput={handleBetInput}
-            details={addBetDetails}
-            setDetails={setAddBetDetails}
-            disabled={disabled}
-            error={errors}
-            handleFocus={handleFocus}
-            handleBlur={handleBlur}
-          />
-        )}
-        <OddsInput
-          handleBetInput={handleBetInput}
-          details={addBetDetails}
-          disabled={disabled}
-          error={errors}
-          setError={setErrors}
-          // handleFocus={handleFocus}
-          // handleBlur={handleBlur}
-        />
-        <DateInput
-          handleBetInput={handleBetInput}
-          details={addBetDetails}
-          disabled={disabled}
+          handleDetailsSelect={handleDetailsSelect}
+          setAddBetDetails={setAddBetDetails}
         />
         <div className="add-bet-buttons">
           <Button2 type="submit" className="btn2-cta" disabled={disabled}>

--- a/client/src/features/add-bet/components/forms/add-bet-form/BetDetailInputs.tsx
+++ b/client/src/features/add-bet/components/forms/add-bet-form/BetDetailInputs.tsx
@@ -11,7 +11,7 @@ import {
 import { BetDetails } from "@/utils";
 import { Dispatch, SetStateAction, ChangeEvent, FocusEvent } from "react";
 
-type BetDetailInputs = {
+type BetDetailInputProps = {
   handleBetInput: (
     e: React.ChangeEvent<
       HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
@@ -39,7 +39,7 @@ export const BetDetailInputs = ({
   handleBlur,
   handleDetailsSelect,
   setAddBetDetails,
-}: BetDetailInputs) => {
+}: BetDetailInputProps) => {
   return (
     <>
       <MatchInput

--- a/client/src/features/add-bet/components/forms/add-bet-form/BetDetailInputs.tsx
+++ b/client/src/features/add-bet/components/forms/add-bet-form/BetDetailInputs.tsx
@@ -1,0 +1,100 @@
+import { isBetBuilderType } from "@/pages/add-bet/betUtils";
+import {
+  BetBuilderInput,
+  DateInput,
+  FreeLiveInput,
+  MatchInput,
+  OddsInput,
+  SelectionInput,
+  TypeInput,
+} from "../../add-bet-inputs";
+import { BetDetails } from "@/utils";
+import { Dispatch, SetStateAction, ChangeEvent, FocusEvent } from "react";
+
+type BetDetailInputs = {
+  handleBetInput: (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => void;
+  handleDetailsSelect: (e: ChangeEvent<HTMLSelectElement>) => void;
+  handleFocus: (e: FocusEvent<HTMLInputElement>) => void;
+  handleBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  addBetDetails: BetDetails;
+  setAddBetDetails: Dispatch<SetStateAction<BetDetails>>;
+  disabled: boolean;
+  setErrors: Dispatch<SetStateAction<{ [key: string]: string }>>;
+  errors: {
+    [key: string]: string;
+  };
+};
+
+export const BetDetailInputs = ({
+  handleBetInput,
+  addBetDetails,
+  disabled,
+  setErrors,
+  errors,
+  handleFocus,
+  handleBlur,
+  handleDetailsSelect,
+  setAddBetDetails,
+}: BetDetailInputs) => {
+  return (
+    <>
+      <MatchInput
+        handleBetInput={handleBetInput}
+        details={addBetDetails}
+        disabled={disabled}
+        error={errors}
+        handleFocus={handleFocus}
+        handleBlur={handleBlur}
+      />
+      <TypeInput
+        handleSelectChange={handleDetailsSelect}
+        details={addBetDetails}
+        disabled={disabled}
+      />
+      <FreeLiveInput
+        handleBetInput={handleBetInput}
+        details={addBetDetails}
+        disabled={disabled}
+      />
+      {isBetBuilderType(addBetDetails.bet_type) ? (
+        <BetBuilderInput
+          handleBetInput={handleBetInput}
+          details={addBetDetails}
+          setDetails={setAddBetDetails}
+          disabled={disabled}
+          error={errors}
+          handleFocus={handleFocus}
+          handleBlur={handleBlur}
+        />
+      ) : (
+        <SelectionInput
+          handleBetInput={handleBetInput}
+          details={addBetDetails}
+          setDetails={setAddBetDetails}
+          disabled={disabled}
+          error={errors}
+          handleFocus={handleFocus}
+          handleBlur={handleBlur}
+        />
+      )}
+      <OddsInput
+        handleBetInput={handleBetInput}
+        details={addBetDetails}
+        disabled={disabled}
+        error={errors}
+        setError={setErrors}
+        // handleFocus={handleFocus}
+        // handleBlur={handleBlur}
+      />
+      <DateInput
+        handleBetInput={handleBetInput}
+        details={addBetDetails}
+        disabled={disabled}
+      />
+    </>
+  );
+};

--- a/client/src/utils/defaults/defaults.ts
+++ b/client/src/utils/defaults/defaults.ts
@@ -1,12 +1,12 @@
 import { BetStatus, BetType, Bookmaker, SportLeague } from "../enums";
+import { BetDetails } from "../types";
 
-export const initialBetDetailValues = {
+export const initialBetDetailValues: BetDetails = {
   home_team: "",
   away_team: "",
   selection: "",
   odds: "",
   date: new Date(),
-  notes: "",
   freebet: false,
   livebet: false,
   home_result: "",

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -15,6 +15,7 @@
       "@hooks/*": ["./src/hooks/*"],
       "@pages/*": ["./src/pages/*"],
       "@store/*": ["./src/store/*"],
+      "@utils": ["./src/utils"],
       "@utils/*": ["./src/utils/*"]
     },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Consolidated multiple bet input fields into a single unified bet-details input section with consistent state, validation, and focus handling; conditional Bet Builder vs Selection behavior preserved.

- Changes
  - Removed the Notes field from the default bet details.

- Chores
  - Added a utilities path alias to simplify imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->