### PR TITLE
closes suggestions on sport input if match found

### DIFF
--- a/client/src/features/add-bet/components/forms/finish-bet-form/FinishBetForm.spec.tsx
+++ b/client/src/features/add-bet/components/forms/finish-bet-form/FinishBetForm.spec.tsx
@@ -82,7 +82,7 @@ describe("FinishBetForm", () => {
 
     // Verify the callback was called
     expect(mockSetMyBet).toHaveBeenCalled();
-    expect(sportInput.value).toBe("NBA");
+    expect(sportInput.value).toBe("CustomSport");
   });
 });
 

--- a/client/src/features/add-bet/components/forms/finish-bet-form/finish-bet-inputs/SportInput.tsx
+++ b/client/src/features/add-bet/components/forms/finish-bet-form/finish-bet-inputs/SportInput.tsx
@@ -35,10 +35,22 @@ export const SportInput = ({ disabled, value, setMyBet }: SportInputProps) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
+
+    setFindSport(newValue);
     setMyBet((prevBet) => ({
       ...prevBet,
       sport: newValue,
     }));
+
+    const exactMatch = allSports.some(
+      (sport) => sport.toLowerCase() === newValue.toLowerCase()
+    );
+
+    if (exactMatch) {
+      setShowSearch(false);
+    } else {
+      setShowSearch(true);
+    }
   };
 
   const handleSelectSuggestion = (sport: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sport input now preserves exact custom values entered by users.
  * Suggestion dropdown is hidden when the entered sport exactly matches an existing option, reducing distraction.
  * Suggestions appear only when there’s no exact match, improving clarity during entry.

* **Tests**
  * Updated tests to reflect the corrected behavior for custom sport input and suggestion visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->